### PR TITLE
[Draft] use pip to install pkgs; use pip to download artifacts for getting de…

### DIFF
--- a/poetry/installation/executor.py
+++ b/poetry/installation/executor.py
@@ -432,9 +432,12 @@ class Executor(object):
         if package.source_type == "file":
             archive = self._prepare_file(operation)
         elif package.source_type == "url":
-            archive = self._download_link(operation, Link(package.source_url))
+            # archive = self._download_link(operation, Link(package.source_url))
+            return self._pip_install(operation, package.source_url)
         else:
-            archive = self._download(operation)
+            # archive = self._download(operation)
+            url = str(self._chooser.choose_for(package))
+            return self._pip_install(operation, url)
 
         operation_message = self.get_operation_message(operation)
         message = "  <fg=blue;options=bold>•</> {message}: <info>Installing...</info>".format(
@@ -445,6 +448,17 @@ class Executor(object):
         args = ["install", "--no-deps", str(archive)]
         if operation.job_type == "update":
             args.insert(2, "-U")
+
+        return self.run_pip(*args)
+
+    def _pip_install(self, operation, spec):
+        operation_message = self.get_operation_message(operation)
+        message = "  <fg=blue;options=bold>•</> {message}: <info>Installing...</info>".format(
+            message=operation_message,
+        )
+        self._write(operation, message)
+
+        args = ["install", "--no-deps", spec]
 
         return self.run_pip(*args)
 

--- a/poetry/repositories/pypi_repository.py
+++ b/poetry/repositories/pypi_repository.py
@@ -76,11 +76,13 @@ class PyPiRepository(RemoteRepository):
         self._cache_control_cache = FileCache(str(release_cache_dir / "_http"))
         self._name = "PyPI"
 
+        home_dir = os.getenv('HOME')
+        pypi = os.getenv('REPLIT_POETRY_PYPI_REPOSITORY') or 'https://pypi.org/pypi/'
         self._pip_session = PipSession(
-            cache='%s/.cache/pip/http' % os.getenv('HOME'),
+            cache='%s/.cache/pip/http' % home_dir,
             retries=None,
             trusted_hosts=[],
-            index_urls=['https://package-proxy.replit.com/pypi/simple/']
+            index_urls=['%ssimple/' % pypi]
         )
 
     @property

--- a/poetry/repositories/pypi_repository.py
+++ b/poetry/repositories/pypi_repository.py
@@ -76,8 +76,8 @@ class PyPiRepository(RemoteRepository):
         self._cache_control_cache = FileCache(str(release_cache_dir / "_http"))
         self._name = "PyPI"
 
-        self._pip_session = session = PipSession(
-            cache='/home/runner/.cache/pip/http',
+        self._pip_session = PipSession(
+            cache='%s/.cache/pip/http' % os.getenv('HOME'),
             retries=None,
             trusted_hosts=[],
             index_urls=['https://package-proxy.replit.com/pypi/simple/']


### PR DESCRIPTION
…p info; prefer wheels over sdist

## Why

Installing a popular package like requests in a repl can take more than 1 minute.

The biggest slowdown comes from the fact that poetry builds most packages from source just to get their dependency info.

## What Changed

0. prefer pre-built wheels over building from source when checking for a package's dep info
1. Use pip's downloader to download artifacts to leverage pip cache
2. Use pip to install packages into venv to leverage pip cache