### PR TITLE
Put the pypi_repository cache dir under the global cache-dir

### DIFF
--- a/poetry/console/commands/init.py
+++ b/poetry/console/commands/init.py
@@ -541,6 +541,6 @@ The <c1>init</c1> command creates a basic <comment>pyproject.toml</> file in the
 
         if self._pool is None:
             self._pool = Pool()
-            self._pool.add_repository(PyPiRepository())
+            self._pool.add_repository(PyPiRepository(config=self.poetry.config))
 
         return self._pool

--- a/poetry/console/commands/self/update.py
+++ b/poetry/console/commands/self/update.py
@@ -126,7 +126,7 @@ class SelfUpdateCommand(Command):
         from poetry.repositories.pypi_repository import PyPiRepository
 
         pool = Pool()
-        pool.add_repository(PyPiRepository(fallback=False))
+        pool.add_repository(PyPiRepository(config=self.poetry.config, fallback=False))
 
         self._pool = pool
 

--- a/poetry/factory.py
+++ b/poetry/factory.py
@@ -96,7 +96,7 @@ class Factory(BaseFactory):
                 io.write_line("Deactivating the PyPI repository")
         else:
             default = not poetry.pool.has_primary_repositories()
-            poetry.pool.add_repository(PyPiRepository(), default, not default)
+            poetry.pool.add_repository(PyPiRepository(config=poetry.config), default, not default)
 
         return poetry
 

--- a/poetry/repositories/pypi_repository.py
+++ b/poetry/repositories/pypi_repository.py
@@ -54,14 +54,17 @@ class PyPiRepository(RemoteRepository):
 
     CACHE_VERSION = parse_constraint("1.0.0")
 
-    def __init__(self, url="https://pypi.org/", disable_cache=False, fallback=True):
+    def __init__(self, config=None, url="https://pypi.org/", disable_cache=False, fallback=True):
         super(PyPiRepository, self).__init__(url.rstrip("/") + "/simple/")
 
+        self._config = config
         self._base_url = url
         self._disable_cache = disable_cache
         self._fallback = fallback
 
         release_cache_dir = REPOSITORY_CACHE_DIR / "pypi"
+        if self._config:
+            release_cache_dir = Path(self._config.get("cache-dir")) / "pypi"
         self._cache = CacheManager(
             {
                 "default": "releases",


### PR DESCRIPTION
## Why

Want to config the cache dir for pypi_repository.py under poetry's globally configured `cache-dir`. Currently, that cache-dir is ignored.

## What changed

1. Updated `pypi_repository.py` to accept a config object from which it will ask for the `cache-dir`.
2. Updated various instantiations of `PypiRepository` to pass in the global config object.