### PR TITLE
handling the case when the releases field of package metadata is null

### DIFF
--- a/poetry/repositories/pypi_repository.py
+++ b/poetry/repositories/pypi_repository.py
@@ -286,7 +286,11 @@ class PyPiRepository(RemoteRepository):
         )
 
         try:
-            version_info = json_data["releases"][version]
+            releases = json_data["releases"]
+            if releases is not None:
+                version_info = releases[version]
+            else:
+                version_info = []
         except KeyError:
             version_info = []
 


### PR DESCRIPTION
# Why

[tmpltester](https://tmpltester.util.repl.co/test-run/7693) informed us we are getting failures when trying to install packages. You can reproduce the following error by making a new Flask or `Python Data Science` repl, and installing `requests`.

```
Replit: Updating package configuration

--> python3 -m poetry add requests
Using version ^2.28.1 for requests

Updating dependencies
Resolving dependencies...

  TypeError

  'NoneType' object is not subscriptable

  at venv/lib/python3.8/site-packages/poetry/repositories/pypi_repository.py:284 in _get_release_info
      280│             cache_version=str(self.CACHE_VERSION),
      281│         )
      282│ 
      283│         try:
    → 284│             version_info = json_data["releases"][version]
      285│         except KeyError:
      286│             version_info = []
      287│ 
      288│         for file_info in version_info:
/home/runner/SlimInfatuatedProduct/venv/lib/python3.8/site-packages/setuptools/command/install.py:34: SetuptoolsDeprecationWarning: setup.py install is deprecated. Use build and pip and other standards-based tools.
  warnings.warn(
exit status 1
```

## What changed

Added None check to handle this case.