### PR TITLE
Th tarball

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@ MANIFEST.in
 /releases/*
 pip-wheel-metadata
 /poetry.toml
+
+poetry-*.tgz
+poetry-bundle

--- a/build-bundle.sh
+++ b/build-bundle.sh
@@ -1,3 +1,12 @@
+# Generate a bundle containing poetry + dependencies
+# for use by Nix using pip's download command to allow offline installs as
+# described here: https://stackoverflow.com/a/36730026
+
+# The generated file is to be uploaded to the poetry-bundles bucket on gcs, available at
+# https://storage.googleapis.com/poetry-bundles/poetry-x.y.z-bundle.tgz
+
+# You may use `nix develop` to gain access the tools used by this script.
+
 set -x
 
 BUILD_DIR=poetry-bundle
@@ -6,6 +15,6 @@ rm -fr $BUILD_DIR
 mkdir -p $BUILD_DIR
 VERSION=$(toml2json pyproject.toml | jq '.tool.poetry.version' --raw-output)
 POETRY_TAR_FILE="poetry-${VERSION}.tgz"
-tar cz --sort=name --mtime='@1' --exclude="$BUILD_DIR" --owner=0 --group=0 --numeric-owner -P -f "$POETRY_TAR_FILE" .
+tar cz --sort=name --mtime='@1' --exclude="$BUILD_DIR" --exclude="$POETRY_TAR_FILE" --owner=0 --group=0 --numeric-owner -P -f "$POETRY_TAR_FILE" .
 pip download "$POETRY_TAR_FILE" -d $BUILD_DIR
 tar czf poetry-${VERSION}-bundle.tgz $BUILD_DIR

--- a/build-bundle.sh
+++ b/build-bundle.sh
@@ -1,0 +1,11 @@
+set -x
+
+BUILD_DIR=poetry-bundle
+
+rm -fr $BUILD_DIR
+mkdir -p $BUILD_DIR
+VERSION=$(toml2json pyproject.toml | jq '.tool.poetry.version' --raw-output)
+POETRY_TAR_FILE="poetry-${VERSION}.tgz"
+tar cz --sort=name --mtime='@1' --exclude="$BUILD_DIR" --owner=0 --group=0 --numeric-owner -P -f "$POETRY_TAR_FILE" .
+pip download "$POETRY_TAR_FILE" -d $BUILD_DIR
+tar czf poetry-${VERSION}-bundle.tgz $BUILD_DIR

--- a/fetch-deps.sh
+++ b/fetch-deps.sh
@@ -1,0 +1,9 @@
+set -x
+
+rm -fr build
+mkdir -p build
+VERSION=$(toml2json pyproject.toml | jq '.tool.poetry.version' --raw-output)
+POETRY_TAR_FILE="build/poetry-${VERSION}.tar.gz"
+tar cz --sort=name --mtime='@1' --exclude="build" --owner=0 --group=0 --numeric-owner -P -f "$POETRY_TAR_FILE" .
+pip download "$POETRY_TAR_FILE" -d build
+tar czf poetry-bundle.tgz ./build

--- a/fetch-deps.sh
+++ b/fetch-deps.sh
@@ -1,9 +1,0 @@
-set -x
-
-rm -fr build
-mkdir -p build
-VERSION=$(toml2json pyproject.toml | jq '.tool.poetry.version' --raw-output)
-POETRY_TAR_FILE="build/poetry-${VERSION}.tar.gz"
-tar cz --sort=name --mtime='@1' --exclude="build" --owner=0 --group=0 --numeric-owner -P -f "$POETRY_TAR_FILE" .
-pip download "$POETRY_TAR_FILE" -d build
-tar czf poetry-bundle.tgz ./build

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1670276674,
+        "narHash": "sha256-FqZ7b2RpoHQ/jlG6JPcCNmG/DoUPCIvyaropUDFhF3Q=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "52e3e80afff4b16ccb7c52e9f0f5220552f03d04",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "52e3e80afff4b16ccb7c52e9f0f5220552f03d04",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -12,6 +12,7 @@
     {
       packages.x86_64-linux.default = pkgs.mkShell {
         packages = [
+          pkgs.python310Full
           pkgs.toml2json
           pkgs.jq
         ];

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,20 @@
+{
+  description = "Nix expressions for defining Replit development environments";
+  inputs.nixpkgs.url = "github:nixos/nixpkgs?rev=52e3e80afff4b16ccb7c52e9f0f5220552f03d04";
+
+  outputs = { self, nixpkgs, ... }:
+    let
+      mkPkgs = system: import nixpkgs {
+        inherit system;
+      };
+      pkgs = mkPkgs "x86_64-linux";
+    in
+    {
+      packages.x86_64-linux.default = pkgs.mkShell {
+        packages = [
+          pkgs.toml2json
+          pkgs.jq
+        ];
+      };
+    };
+}


### PR DESCRIPTION
# Why?

In order for nixpkgs-replit to build a custom of poetry properly, we needed a reproducible way of installing this version of poetry. This scheme generates a poetry bundle tarball that contains poetry + its dependencies, which then can be used to install it into a virtual env via offline installation.

## Changes

1. added build_bundle.sh script
2. added a flake providing the tools used in the script