### PR TITLE
updated build-bundle.sh script and readme

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,7 +28,7 @@ jobs:
     strategy:
       matrix:
         os: [Ubuntu, macOS, Windows]
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
         include:
           - os: Ubuntu
             image: ubuntu-22.04

--- a/README.md
+++ b/README.md
@@ -112,3 +112,17 @@ external formats like virtual environments
 * [install.python-poetry.org](https://github.com/python-poetry/install.python-poetry.org): The official Poetry
 installation script
 * [website](https://github.com/python-poetry/website): The official Poetry website and blog
+
+## Bundle
+
+For the Replit [Python Nix modules](https://github.com/replit/nixmodules/tree/main/pkgs/modules/python), we build a separate Poetry bundle for each supported version of Python 
+containing Poetry plus all its dependencies and uploaded it to gcf. To build a bundle:
+
+1. Make sure you have the correct version of Python and Pip, and that they match.
+2. Get access to the latest version of poetry.
+3. If you are working in a Repl, using a Python Nix module should give you all 3.
+4. Run `build-bundle.sh`
+5. It should produce a file `poetry-${VERSION}-python-${PYTHON_VERSION}-bundle.tgz` in `dist`
+6. Upload this to gcf in the `poetry-bundles` of the Goval project.
+7. Click on the ... and choose "Copy Public URL" for use in the poetry derivation back in
+[Nix modules](https://github.com/replit/nixmodules)

--- a/build-bundle.sh
+++ b/build-bundle.sh
@@ -14,9 +14,10 @@ BUILD_DIR=poetry-bundle
 rm -fr $BUILD_DIR
 mkdir -p $BUILD_DIR
 VERSION=$(toml2json pyproject.toml | jq '.tool.poetry.version' --raw-output)
-POETRY_TAR_FILE="poetry-${VERSION}.tgz"
-tar cz --sort=name --mtime='@1' --owner=0 --group=0 --numeric-owner -P -f "$POETRY_TAR_FILE" src pyproject.toml LICENSE README.md
-pip download "$POETRY_TAR_FILE" -d $BUILD_DIR
-tar czf poetry-${VERSION}-bundle.tgz $BUILD_DIR
-rm "$POETRY_TAR_FILE"
+POETRY_WHEEL_FILE="dist/poetry-${VERSION}-py3-none-any.whl"
+PYTHON_VERSION=$(python -c 'import platform; print(platform.python_version())')
+poetry build
+pip download "$POETRY_WHEEL_FILE" -d $BUILD_DIR
+tar czf dist/poetry-${VERSION}-python-${PYTHON_VERSION}-bundle.tgz $BUILD_DIR
+rm "$POETRY_WHEEL_FILE"
 rm -fr "$BUILD_DIR"


### PR DESCRIPTION
# Why?

Added intructions to how to build a poetry bundle and uploaded

## Changes

1. Use `poetry build` to build the wheel file instead of tarring the source ourselves
2. Name target bundle with the Python version number
3. Added docs