### PR TITLE
Headers, shebang, and curl fixes

### DIFF
--- a/src/poetry/installation/wheel_installer.py
+++ b/src/poetry/installation/wheel_installer.py
@@ -99,7 +99,7 @@ class WheelDestination(SchemeDictionaryDestination):
                   sys.version_info.minor
                 )
                 source_distribution = self.scheme_dict["headers"].split("/")[-1]
-                basepath = str(Path(headers_path) / source_distribution)
+                basepath = "%s/%s" % (headers_path, source_distribution)
         if basepath is None:
              basepath = self.scheme_dict[scheme]
         return basepath

--- a/src/poetry/installation/wheel_installer.py
+++ b/src/poetry/installation/wheel_installer.py
@@ -11,10 +11,11 @@ from installer import install
 from installer.destinations import SchemeDictionaryDestination
 from installer.sources import WheelFile
 from installer.sources import _WheelFileValidationError
+import installer.scripts
 
 from poetry.__version__ import __version__
 from poetry.utils._compat import WINDOWS
-
+import installer.scripts
 
 if TYPE_CHECKING:
     from typing import BinaryIO
@@ -25,6 +26,13 @@ if TYPE_CHECKING:
 
     from poetry.utils.env import Env
 
+shebang = '#!/usr/bin/env python'.encode("utf-8")
+
+def _build_shebang(executable: str, forlauncher: bool) -> bytes:
+    return shebang
+
+# monkey patch _build_shebang implementation
+installer.scripts._build_shebang = _build_shebang
 
 class WheelDestination(SchemeDictionaryDestination):
     """ """
@@ -84,6 +92,14 @@ class WheelDestination(SchemeDictionaryDestination):
                 basepath = self.scheme_dict["userbase"]
             elif scheme == "scripts" and "userbase" in self.scheme_dict:
                 basepath = self.scheme_dict["userbase"] + "/bin"
+            elif scheme == "headers" and "userbase" in self.scheme_dict:
+                headers_path = "%s/include/python-%s.%s" % (
+                  self.scheme_dict["userbase"], 
+                  sys.version_info.major, 
+                  sys.version_info.minor
+                )
+                source_distribution = self.scheme_dict["headers"].split("/")[-1]
+                basepath = str(Path(headers_path) / source_distribution)
         if basepath is None:
              basepath = self.scheme_dict[scheme]
         return basepath

--- a/src/poetry/utils/helpers.py
+++ b/src/poetry/utils/helpers.py
@@ -152,7 +152,13 @@ def download_file_with_curl(
     Based on benchmarks done with tensorflow==2.15.0 and torch, using curl for downloading
     large files gives ~30% faster than requests for the overall installation time.
     """
-    subprocess.run(['curl', url, '--silent', '--output', dest], check=True)
+    subprocess.run(
+        ['curl', url, '--silent', '--output', dest], 
+        check=True,
+        env={
+          'LD_LIBRARY_PATH': ''
+        }
+    )
 
 def get_package_version_display_string(
     package: Package, root: Path | None = None


### PR DESCRIPTION
# Why

Found some [breakages](https://replit.slack.com/archives/C04E0RA5WH5/p1702409499416399?thread_ts=1702399815.580939&cid=C04E0RA5WH5) from https://github.com/replit/poetry/pull/27:

Issues found:
1. pygame/langchain/greenlet - [Errno 13] Permission denied: '/nix/store/xf54733x4chbawkh1qvy9i1i4mlscy1c-python3-3.10.11/include/python3.10/greenlet' due to failing to handle install scheme of "header"
2. streamlit / gunicorn - ImportError: libstdc++.so.6: cannot open shared object file: No such file or directory - shebang line in scripts are hardcoded to python path, we'll need to make this flexible like the way we did in the pip implementation
3. curl: symbol lookup error: /nix/store/dg8mpqqykmw9c7l0bgzzb5znkymlbfjw-glibc-2.37-8/lib/libc.so.6: undefined symbol: _dl_audit_symbind_alt, version GLIBC_PRIVATE on install- this happens if sysdeps updates PYTHON_LD_LIBRARY_PATH

## Changes

1. Fixed 1 by adding a directory mapping headers scheme
2. unified path mapping code into for_source, which required less overriding of code and fewer changes vs upstream overall
3. Fixed 2 by monkey patching the `_build_shebang` function to return "!/usr/bin/env python"
4. Fixed 3 by unsetting LD_LIBRARY_PATH when calling curl

# Testing

* use test instructions from https://github.com/replit/poetry/pull/27