### PR TITLE
bug/Poetry Runtime: Elide USERBASE with poetry internal deps

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,8 +93,7 @@ optional = true
 pytest-github-actions-annotate-failures = "^0.1.7"
 
 [tool.poetry.scripts]
-poetry = "poetry.console.application:main"
-
+poetry = "poetry.replit:main"
 
 [build-system]
 requires = ["poetry-core>=1.5.0"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "poetry"
-version = "1.5.3"
+version = "1.5.4"
 description = "Python dependency management and packaging made easy."
 authors = ["Sébastien Eustace <sebastien@eustace.io>"]
 maintainers = [

--- a/src/poetry/__main__.py
+++ b/src/poetry/__main__.py
@@ -1,9 +1,20 @@
 from __future__ import annotations
 
 import sys
-
+import os
 
 if __name__ == "__main__":
+    # Explicitly remove PYTHONUSERBASE from sys.path without touching PYTHONPATH.
+    # We may need additional libraries supplied by the environment, but we should
+    # do our best to insulate ourselves from the user's site-packages.
+    #
+    # Unfortunately, `poetry remove` delegates to `pip uninstall`, so simply
+    # removing PYTHONUSERBASE from PYTHONPATH will prevent anything from
+    # being uninstalled.
+    userbase = os.getenv('PYTHONUSERBASE')
+    if userbase:
+        sys.path = [x for x in sys.path if not x.startswith(userbase)]
+
     from poetry.console.application import main
 
     sys.exit(main())

--- a/src/poetry/__version__.py
+++ b/src/poetry/__version__.py
@@ -16,4 +16,4 @@ version: Callable[[str], str] = metadata.version
 try:
   __version__ = version("poetry")
 except:
-  __version__ = "1.5.3"
+  __version__ = "1.5.4"

--- a/src/poetry/replit.py
+++ b/src/poetry/replit.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+import sys
+import os
+
+# Explicitly remove PYTHONUSERBASE from sys.path without touching PYTHONPATH.
+# We may need additional libraries supplied by the environment, but we should
+# do our best to insulate ourselves from the user's site-packages.
+#
+# Unfortunately, `poetry remove` delegates to `pip uninstall`, so simply
+# removing PYTHONUSERBASE from PYTHONPATH will prevent anything from
+# being uninstalled.
+userbase = os.getenv('PYTHONUSERBASE')
+if userbase:
+    sys.path = [x for x in sys.path if not x.startswith(userbase)]
+
+# Re-export main in a way that Pyright doesn't complain about
+import poetry.console.application
+main = poetry.console.application.main


### PR DESCRIPTION
Resolves https://ask.replit.com/t/nix-error-when-installing-or-uninstalling-packages/94756

The problem we were facing was that html5lib===1.0b8 was a dependency of redberry, which relied on python <=3.7.

    ~/ReplWorkspace$ poetry add redberry

    cannot import name 'Mapping' from 'collections' (/nix/store/xf54733x4chbawkh1qvy9i1i4mlscy1c-python3-3.10.11/lib/python3.10/collections/__init__.py)

We need to preserve the full PYTHONPATH because poetry executes pip to uninstall packages, and if PYTHONPATH does not contain the PYTHONUSERBASE then it will silently not uninstall packages.