### PR TITLE
Added module_name conversion to fix proj name comparison; backport pr…

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "poetry"
-version = "1.5.4"
+version = "1.5.5"
 description = "Python dependency management and packaging made easy."
 authors = ["Sébastien Eustace <sebastien@eustace.io>"]
 maintainers = [

--- a/src/poetry/__version__.py
+++ b/src/poetry/__version__.py
@@ -16,4 +16,4 @@ version: Callable[[str], str] = metadata.version
 try:
   __version__ = version("poetry")
 except:
-  __version__ = "1.5.4"
+  __version__ = "1.5.5"

--- a/src/poetry/layouts/layout.py
+++ b/src/poetry/layouts/layout.py
@@ -96,7 +96,7 @@ class Layout:
         if self.basedir != Path():
             package.append("from", self.basedir.as_posix())
         else:
-            if include == self._project:
+            if module_name(self._project) == include:
                 # package include and package name are the same,
                 # packages table is redundant here.
                 return None

--- a/tests/console/commands/test_init.py
+++ b/tests/console/commands/test_init.py
@@ -13,6 +13,7 @@ import pytest
 
 from cleo.testers.command_tester import CommandTester
 from packaging.utils import canonicalize_name
+from poetry.core.utils.helpers import module_name
 
 from poetry.console.application import Application
 from poetry.console.commands.init import InitCommand
@@ -86,7 +87,6 @@ description = "This is a description"
 authors = ["Your Name <you@example.com>"]
 license = "MIT"
 readme = "README.md"
-packages = [{include = "my_package"}]
 
 [tool.poetry.dependencies]
 python = "~2.7 || ^3.6"
@@ -169,7 +169,6 @@ description = "This is a description"
 authors = ["Your Name <you@example.com>"]
 license = "MIT"
 readme = "README.md"
-packages = [{include = "my_package"}]
 
 [tool.poetry.dependencies]
 python = "~2.7 || ^3.6"
@@ -218,7 +217,6 @@ description = "This is a description"
 authors = ["Your Name <you@example.com>"]
 license = "MIT"
 readme = "README.md"
-packages = [{include = "my_package"}]
 
 [tool.poetry.dependencies]
 python = "~2.7 || ^3.6"
@@ -249,7 +247,6 @@ version = "1.2.3"
 description = ""
 authors = ["Your Name <you@example.com>"]
 readme = "README.md"
-packages = [{{include = "my_package"}}]
 
 [tool.poetry.dependencies]
 python = "^{python}"
@@ -290,7 +287,6 @@ description = "This is a description"
 authors = ["Your Name <you@example.com>"]
 license = "MIT"
 readme = "README.md"
-packages = [{include = "my_package"}]
 
 [tool.poetry.dependencies]
 python = "~2.7 || ^3.6"
@@ -383,7 +379,6 @@ description = "This is a description"
 authors = ["Your Name <you@example.com>"]
 license = "MIT"
 readme = "README.md"
-packages = [{include = "my_package"}]
 
 [tool.poetry.dependencies]
 python = "~2.7 || ^3.6"
@@ -429,7 +424,6 @@ description = "This is a description"
 authors = ["Your Name <you@example.com>"]
 license = "MIT"
 readme = "README.md"
-packages = [{include = "my_package"}]
 
 [tool.poetry.dependencies]
 python = "~2.7 || ^3.6"
@@ -481,7 +475,6 @@ description = "This is a description"
 authors = ["Your Name <you@example.com>"]
 license = "MIT"
 readme = "README.md"
-packages = [{include = "my_package"}]
 
 [tool.poetry.dependencies]
 python = "~2.7 || ^3.6"
@@ -532,7 +525,6 @@ description = "This is a description"
 authors = ["Your Name <you@example.com>"]
 license = "MIT"
 readme = "README.md"
-packages = [{include = "my_package"}]
 
 [tool.poetry.dependencies]
 python = "~2.7 || ^3.6"
@@ -584,7 +576,6 @@ description = "This is a description"
 authors = ["Your Name <you@example.com>"]
 license = "MIT"
 readme = "README.md"
-packages = [{include = "my_package"}]
 
 [tool.poetry.dependencies]
 python = "~2.7 || ^3.6"
@@ -629,7 +620,6 @@ description = "This is a description"
 authors = ["Your Name <you@example.com>"]
 license = "MIT"
 readme = "README.md"
-packages = [{include = "my_package"}]
 
 [tool.poetry.dependencies]
 python = "^3.8"
@@ -664,7 +654,6 @@ description = "This is a description"
 authors = ["Your Name <you@example.com>"]
 license = "MIT"
 readme = "README.md"
-packages = [{include = "my_package"}]
 
 [tool.poetry.dependencies]
 python = "~2.7 || ^3.6"
@@ -697,7 +686,6 @@ description = "This is a description"
 authors = ["Your Name <you@example.com>"]
 license = "MIT"
 readme = "README.md"
-packages = [{include = "my_package"}]
 
 [tool.poetry.dependencies]
 python = "~2.7 || ^3.6"
@@ -739,7 +727,6 @@ description = "This is a description"
 authors = ["Your Name <you@example.com>"]
 license = "MIT"
 readme = "README.md"
-packages = [{include = "my_package"}]
 
 [tool.poetry.dependencies]
 python = "~2.7 || ^3.6"
@@ -775,7 +762,6 @@ description = "This is a description"
 authors = ["Your Name <you@example.com>"]
 license = "MIT"
 readme = "README.md"
-packages = [{include = "my_package"}]
 
 [tool.poetry.dependencies]
 python = "~2.7 || ^3.6"
@@ -819,7 +805,6 @@ description = "This is a description"
 authors = ["Your Name <you@example.com>"]
 license = "MIT"
 readme = "README.md"
-packages = [{include = "my_package"}]
 
 [tool.poetry.dependencies]
 python = "~2.7 || ^3.6"
@@ -868,7 +853,6 @@ description = "This is a description"
 authors = ["Foo Bar <foo@example.com>"]
 license = "MIT"
 readme = "README.md"
-packages = [{include = "my_package"}]
 
 [tool.poetry.dependencies]
 python = "^3.8"
@@ -963,7 +947,6 @@ version = "0.1.0"
 description = ""
 authors = ["Your Name <you@example.com>"]
 readme = "README.md"
-packages = [{include = "my_package"}]
 
 [tool.poetry.dependencies]
 python = "^3.6"
@@ -1047,7 +1030,9 @@ def test_package_include(
         ),
     )
 
-    packages = "" if include is None else f'packages = [{{include = "{include}"}}]\n'
+    packages = ""
+    if include and module_name(package_name) != include:
+        packages = f'packages = [{{include = "{include}"}}]\n'
 
     expected = (
         f"[tool.poetry]\n"

--- a/tests/console/commands/test_new.py
+++ b/tests/console/commands/test_new.py
@@ -9,6 +9,8 @@ from typing import Any
 
 import pytest
 
+from poetry.core.utils.helpers import module_name
+
 from poetry.factory import Factory
 
 
@@ -55,10 +57,11 @@ def verify_project_directory(
     else:
         package_include = {"include": package_path.parts[0]}
 
+    name = poetry.local_config.get("name", "")
     packages = poetry.local_config.get("packages")
 
     if not packages:
-        assert poetry.local_config.get("name") == package_include.get("include")
+        assert module_name(name) == package_include.get("include")
     else:
         assert len(packages) == 1
         assert packages[0] == package_include


### PR DESCRIPTION
… 8218


# Why?

If you do

`poetry init --no-interaction --name foo_bar`

to init a poetry project. It erronously creates a  `packages = [{include = "foo_bar"}]` entry in `pyproject.toml`, causing poetry later to fail because `foo_bar` is not a subdirectory.

More context: https://replit.slack.com/archives/C03KS2B221W/p1723577758114809?thread_ts=1723568638.858709&cid=C03KS2B221W

# Change

This was [fixed in a newer version of poetry upstream](https://github.com/python-poetry/poetry/pull/8218). Cherry-picked the [merge commit](https://github.com/python-poetry/poetry/commit/dfd0db8366301087bcb1b596e0344cd0450448e5).

## Test

`poetry init --no-interaction --name foo_bar`

now no longer creates a `packages` entry.