### PR TITLE
Security update 2

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1905,4 +1905,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "62a93924f33ed940e28124e3d4264839c966f6b01b3f559bc0fa5a1ff65212ae"
+content-hash = "d60f69d4c63f855f8899fc7b26d2aecde40b2b9b16630d40d6af35c2a14f3401"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,7 @@ tomlkit = ">=0.11.4,<1.0.0"
 trove-classifiers = ">=2022.5.19"
 virtualenv = "^20.29.2"
 xattr = { version = "^0.10.0", markers = "sys_platform == 'darwin'" }
-urllib3 = "^1.26.0"
+urllib3 = "^1.26.20"
 
 [tool.poetry.group.dev.dependencies]
 pre-commit = "^2.6"


### PR DESCRIPTION
# Why

For some reason dependabot didn't pick up the update to urllib3 in poetry.lock eventhough it is updated. Trying to do it explicitly.

## Change

Updated pyproject.toml and then poetry lock/install.